### PR TITLE
Set site description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 title: Functional Programming at the University of Kansas
 email: your-email@domain.com
-description: "Write an awesome description for your new site here. You can edit this line in _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description."
+description: "The Functional Programming Group at the University of Kansas apply and extend functional programming technologies to the diverse areas of building computer systems, high-performance computing, information assurance and telemetry."
 baseurl: ""
 url: "http://yourdomain.com"
 twitter_username: jekyllrb


### PR DESCRIPTION
When a friend of mine linked to this site this is what I saw: https://www.dropbox.com/s/0k17wsdelxzv2mp/Screenshot%202015-03-25%2013.37.42.png?dl=0

I pulled the first sentence from the home page and set it for your description. I feel like `apply and extend` should be `applies and extends` but I didn't want to overstep (^_^)

Also the url, email, twitter username, and github username fields should be updated but I don't know what to put there.